### PR TITLE
Convert to an ES6 module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,1 @@
-var Processor = require('./processor');
-
-exports.Processor = Processor;
+export { default as Processor } from './processor';

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,4 +1,4 @@
-var newImageData = require('./util').newImageData;
+import newImageData from './util';
 
 /**
  * Create a function for running operations.  This function is serialized for
@@ -285,4 +285,4 @@ Processor.prototype._resolveJob = function() {
   this._dispatch();
 };
 
-module.exports = Processor;
+export default Processor;

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,4 +17,4 @@ function newImageData(data, width, height) {
   }
 }
 
-exports.newImageData = newImageData;
+export default newImageData;


### PR DESCRIPTION
Hello @tschaub,
I have converted the piwelworks library to the ES6 module.
Currently it is not possible to use this library together with OpenLayers in Polymer project because the CommonJS modules (require function and module.exports) are not allowed.

This can be solved by using special build tool chain like Webpack but it would be great to align with standard ES6.

Thank you for considering this change,
Jan
